### PR TITLE
Fix position of closing bracket and `#endif` for `DRAW_ON_SCREEN`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,9 +82,9 @@ void loop()
     lcd.fillRect(x - 2, y - 2, 5, 5, TFT_RED);
     lcd.setCursor(380, 0);
     lcd.printf("Touch:(%03d,%03d)", x, y);
-    // }
-#endif
   }
+#endif
+}
 
   /*** Display callback to flush the buffer to screen ***/
   void display_flush(lv_disp_drv_t * disp, const lv_area_t *area, lv_color_t *color_p)


### PR DESCRIPTION
When `DRAW_ON_SCREEN` was defined, it would lead to functions being declared inside of the main function, and the code would not compile. This moves the closing bracket and `#endif` directive so that defining `DRAW_ON_SCREEN` works as expected.

Now when `DRAW_ON_SCREEN` is defined, this correctly enables the entire `if` block with its opening and closing brackets inside of the `main` function.


P.S. Thanks for making this demo available! This is very useful given the complete lack of documentation for the WT32-SC01.